### PR TITLE
Improve documentation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -107,7 +107,7 @@ Have a following maven dependency in your `pom.xml`.
 </dependency>
 ----
 
-Visit https://oss.sonatype.org/[oss.sonatype.org] to figure out the most recent version of `valid8j`.
+Visit https://oss.sonatype.org/#nexus-search;quick~valid8j[oss.sonatype.org] to figure out the most recent version of `valid8j`.
 Check https://valid8j.github.io/valid8j/[valid8j]'s documentation site for more detail.
 
 [bibliography]

--- a/src/site/asciidoc/valid8j-2-getting-started.adoc
+++ b/src/site/asciidoc/valid8j-2-getting-started.adoc
@@ -14,7 +14,7 @@ Have a following maven dependency in your `pom.xml`.
 </dependency>
 ----
 
-Visit https://oss.sonatype.org/[oss.sonatype.org] to figure out the most recent version of `valid8j`.
+Visit https://oss.sonatype.org/#nexus-search;quick~valid8j[oss.sonatype.org] to figure out the most recent version of `valid8j`.
 
 == Fluent Style
 


### PR DESCRIPTION
Make the link to oss.sonatype.org include a query for `valid8j`.
