### PR TITLE
Add not method to Chekcer and improve code convention

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,13 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <codeStyleSettings language="JAVA">
+      <option name="ALIGN_MULTILINE_CHAINED_METHODS" value="true" />
+      <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="true" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/src/main/java/com/github/valid8j/pcond/core/fluent/AbstractObjectChecker.java
+++ b/src/main/java/com/github/valid8j/pcond/core/fluent/AbstractObjectChecker.java
@@ -1,43 +1,93 @@
 package com.github.valid8j.pcond.core.fluent;
 
 import com.github.valid8j.pcond.core.refl.MethodQuery;
-import com.github.valid8j.pcond.forms.Predicates;
 import com.github.valid8j.pcond.forms.Functions;
+import com.github.valid8j.pcond.forms.Predicates;
 
+/**
+ * // @formatter:off
+ * An interface that defines to check a target object.
+ * // @formatter:on
+ */
 public interface AbstractObjectChecker<
     V extends Checker<V, T, R>,
     T,
     R> extends
     Checker<V, T, R> {
+  /**
+   * Adds a predicate to this checker object to check if the target object is NOT `null`.
+   *
+   * @return The updated checker object.
+   */
   default V notNull() {
     return this.checkWithPredicate(Predicates.isNotNull());
   }
 
+  /**
+   * Adds a predicate to this checker object to check if the target object IS `null`.
+   *
+   * @return The updated checker object.
+   */
   default V nullValue() {
     return this.checkWithPredicate(Predicates.isNull());
   }
 
   /**
-   * Checks the object with an argument if they are "equal", using `equalTo` method.
+   * Adds a predicate to this checker object to check the target object with the argument for `anotherObject` if they
+   * are "equal", using `equalTo` method.
    *
-   * @return the updated object.
+   * @param anotherObject An object with which the target object of this checker should be checked.
+   * @return The updated checker object.
    */
   default V equalTo(Object anotherObject) {
     return this.checkWithPredicate(Predicates.isEqualTo(anotherObject));
   }
 
+  /**
+   * Adds a predicate to this checker object to check the target object and the argument for `anotherObject` if they
+   * are referencing the same object.
+   *
+   * @param anotherObject An object with which the target object of this checker should be checked.
+   * @return The updated checker object.
+   */
   default V sameReferenceAs(Object anotherObject) {
     return this.checkWithPredicate(Predicates.isSameReferenceAs(anotherObject));
   }
 
+  /**
+   * Adds a predicate to this checker object to check if the target object is an instance of `Class klass`.
+   *
+   * @param klass A class to check if the target object is an instance of.
+   * @return The updated checker object.
+   */
   default V instanceOf(Class<?> klass) {
     return this.checkWithPredicate(Predicates.isInstanceOf(klass));
   }
 
+  /**
+   * Adds a predicate to this checker object to check if the target object returns `true` if a method specified by
+   * `methodName` and `args` is invoked.
+   * The method to be invoked is chosen by {@link MethodQuery#instanceMethod(Object, String, Object[])}.
+   *
+   * @param methodName A nme of method to be invoked.
+   * @param args       Arguments to be passed by the method.
+   * @return The updated object.
+   * @see MethodQuery#instanceMethod(Object, String, Object[])
+   */
   default V invoke(String methodName, Object... args) {
     return this.checkWithPredicate(Predicates.callp(MethodQuery.instanceMethod(Functions.parameter(), methodName, args)));
   }
 
+  /**
+   * Checks if a static method specified by `klass`, `methodName`, and `args`.
+   * The method to be invoked is chosen by {@link MethodQuery#classMethod(Class, String, Object[])}.
+   * To specify the target object as an argument, you can use the value returned from {@link Functions#parameter()}.
+   *
+   * @param klass      A class to which the static method to be invoked belongs.
+   * @param methodName The name of the method to be invoked.
+   * @param args       Arguments to be passed to the method to be invoked.
+   * @see MethodQuery#classMethod(Class, String, Object[])
+   */
   default V invokeStatic(Class<?> klass, String methodName, Object... args) {
     return this.checkWithPredicate(Predicates.callp(MethodQuery.classMethod(klass, methodName, args)));
   }

--- a/src/main/java/com/github/valid8j/pcond/core/fluent/Checker.java
+++ b/src/main/java/com/github/valid8j/pcond/core/fluent/Checker.java
@@ -1,6 +1,7 @@
 package com.github.valid8j.pcond.core.fluent;
 
 import com.github.valid8j.pcond.fluent.Statement;
+import com.github.valid8j.pcond.forms.Predicates;
 
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -9,12 +10,15 @@ import java.util.function.Supplier;
 import static java.util.Objects.requireNonNull;
 
 /**
+ * // @formatter:off
  * An interface that defines methods to check a target value.
  * By default, calls of checking methods defined in this and sub-interfaces of this interface will be a conjunction of them.
  * To make it a disjunction, call {@link Checker#anyOf()}.
  *
  * User-exposing methods to check values in this method names should be progressive and its objective so that they can
  * follow "to be" or "satisfies" in an English sentence.
+ *
+ * // @formatter:on
  *
  * @param <V> The type of the checker.
  * @param <T> The type from which the target value is transformed.
@@ -25,9 +29,9 @@ public interface Checker<
     T,
     R> extends
     Matcher<V, T, R>,
-        Statement<T> {
-  V addCheckPhrase(Function<Checker<?, R, R>, Predicate<R>> clause);
-  
+    Statement<T> {
+  V addCheckPhrase(Function<Checker<?, R, R>, Predicate<R>> phrase);
+
   /**
    * Checks if the target value satisfies the given `predicate`.
    *
@@ -39,7 +43,7 @@ public interface Checker<
     requireNonNull(predicate);
     return addCheckPhrase(w -> (Predicate<R>) predicate);
   }
-  
+
   /**
    * A synonym of {@link Checker#checkWithPredicate(Predicate)}.
    *
@@ -49,7 +53,7 @@ public interface Checker<
   default V predicate(Predicate<? super R> predicate) {
     return checkWithPredicate(predicate);
   }
-  
+
   /**
    * Convert this object into a printable predicate to check the target value.
    *
@@ -58,7 +62,12 @@ public interface Checker<
   default Predicate<T> done() {
     return statementPredicate();
   }
-  
+
+  @SuppressWarnings("unchecked")
+  default V not(Function<V, V> phrase) {
+    return this.addCheckPhrase((v) -> (Predicate<R>) Predicates.not(phrase.apply((V) v).done()));
+  }
+
   /**
    * // @formatter:off
    * When you use an assertion method that accepts multiple statements (`Statement`), it requires all the elements in the array (`varargs`) should have the same generic parameter type.
@@ -106,8 +115,8 @@ public interface Checker<
 
     @SuppressWarnings("unchecked")
     @Override
-    public V addCheckPhrase(Function<Checker<?, R, R>, Predicate<R>> clause) {
-      return this.addPredicate((Matcher<?, R, R> v) -> clause.apply((Checker<?, R, R>) v));
+    public V addCheckPhrase(Function<Checker<?, R, R>, Predicate<R>> phrase) {
+      return this.addPredicate((Matcher<?, R, R> v) -> phrase.apply((Checker<?, R, R>) v));
     }
 
     @Override

--- a/src/site/asciidoc/valid8j-1-introduction.adoc
+++ b/src/site/asciidoc/valid8j-1-introduction.adoc
@@ -47,6 +47,7 @@ public class IntroductionExample {
             .equalTo(110),
         that(message)
             .satisfies()
+            .not(v -> v.nullValue())
             .startingWith("Kirin Ichiban"));
   }
 }
@@ -65,7 +66,9 @@ a|
                        ->    substringAfter[:]         ->"108"
     "108"              ->    parseInt                  ->108
 [0] 108                ->  THEN:=[110]                 ->true
-    "Kirin Ichiban:108"->WHEN:startsWith[Kirin Ichiban]->true
+    "Kirin Ichiban:108"->WHEN:allOf                    ->true
+                       ->    not:isNull                ->true
+                       ->    startsWith[Kirin Ichiban] ->true
 
 .Detail of failure [0]
 ---
@@ -79,7 +82,9 @@ a|
                        ->    substringAfter[:]         ->"108"
     "108"              ->    parseInt                  ->108
 [0] 108                ->  THEN:=[110]                 ->false
-    "Kirin Ichiban:108"->WHEN:startsWith[Kirin Ichiban]->true
+    "Kirin Ichiban:108"->WHEN:allOf                    ->true
+                       ->    not:isNull                ->true
+                       ->    startsWith[Kirin Ichiban] ->true
 
 .Detail of failure [0]
 ---

--- a/src/test/java/com/github/valid8j/examples/fluent/Fluent3Example.java
+++ b/src/test/java/com/github/valid8j/examples/fluent/Fluent3Example.java
@@ -1,5 +1,6 @@
 package com.github.valid8j.examples.fluent;
 
+import com.github.valid8j.pcond.core.fluent.AbstractObjectChecker;
 import com.github.valid8j.utils.reporting.ReportParser;
 import org.junit.ComparisonFailure;
 import org.junit.Ignore;
@@ -58,6 +59,15 @@ public class Fluent3Example {
               .toBe()
               .notNull()
               .nullValue());
+    }
+
+    @Test(expected = ComparisonFailure.class)
+    public void thirdExample_c() {
+      assertAll(
+              stringValue(null)
+                      .anyOf()
+                      .toBe()
+                      .not(AbstractObjectChecker::nullValue));
     }
 
     @Test(expected = ComparisonFailure.class)

--- a/src/test/java/com/github/valid8j/examples/misc/IntroductionExample.java
+++ b/src/test/java/com/github/valid8j/examples/misc/IntroductionExample.java
@@ -43,6 +43,7 @@ public class IntroductionExample {
     return String.format("%s:%s", name, price);
   }
 
+  @SuppressWarnings("Convert2MethodRef")
   @TestMethodExpectation(FAILURE)
   @Test
   public void exampleMethod() {
@@ -56,6 +57,7 @@ public class IntroductionExample {
             .equalTo(110),
         that(message)
             .satisfies()
+            .not(v -> v.nullValue())
             .startingWith("Kirin Ichiban"));
   }
 }


### PR DESCRIPTION
- Implement 'not(Function<V,V>)' to  interface.
- Improve documentation of  `interface`.
- Add  to cover the new method.

Also, 
- Make use of "Project" code style settings 
- Improve the code convention to align chained method calls