### PR TITLE
Issue-#17: Improve 'Mismatch' message

### DIFF
--- a/src/main/java/com/github/valid8j/pcond/validator/Explanation.java
+++ b/src/main/java/com/github/valid8j/pcond/validator/Explanation.java
@@ -52,7 +52,6 @@ public class Explanation {
       if (i < Math.min(e.length, a.length) && Objects.equals(e[i], a[i])) {
         b.add(format("          %s", a[i]));
       } else {
-        b.add(format("Mismatch<:%s", i < e.length ? e[i] : ""));
         b.add(format("Mismatch>:%s", i < a.length ? a[i] : ""));
       }
     }

--- a/src/test/java/com/github/valid8j/ut/bugfixes/Issue11Test.java
+++ b/src/test/java/com/github/valid8j/ut/bugfixes/Issue11Test.java
@@ -27,15 +27,12 @@ public class Issue11Test extends TestBase {
       assertThat(lineAt(e.getMessage(), ++i), containsString("and"));
       // skip diff line
       ++i;
-      ++i;
       assertThat(lineAt(e.getMessage(), i), containsString("size"));
       assertThat(lineAt(e.getMessage(), ++i), containsString("check"));
       assertThat(lineAt(e.getMessage(), i), containsString("isEqualTo[1]"));
       assertThat(lineAt(e.getMessage(), ++i), containsString("at[0]"));
       assertThat(lineAt(e.getMessage(), ++i), containsString("check"));
       assertThat(lineAt(e.getMessage(), i), containsString("and"));
-      // skip diff line
-      ++i;
       assertThat(lineAt(e.getMessage(), ++i), containsString("isNotNull"));
       assertThat(lineAt(e.getMessage(), ++i), containsString("isInstanceOf"));
       // skip diff line

--- a/src/test/java/com/github/valid8j/ut/experimentals/DbCCurriedFunctionsTest.java
+++ b/src/test/java/com/github/valid8j/ut/experimentals/DbCCurriedFunctionsTest.java
@@ -39,7 +39,7 @@ public class DbCCurriedFunctionsTest extends TestBase {
    * A {@code Context} may have one or more values at once and those values are indexed.
    */
   @Test
-  public void hello() {
+  public void performCurriedPredicate() {
     validate(
         asList("hello", "world"),
         transform(stream().andThen(nest(asList("1", "2", "o"))))
@@ -145,15 +145,7 @@ public class DbCCurriedFunctionsTest extends TestBase {
       assertThat(
           lineAt(e.getMessage(), ++i),
           CoreMatchers.allOf(
-              CoreMatchers.containsString("anyMatch"),
-              CoreMatchers.containsString("curry"),
-              CoreMatchers.containsString("isNull"),
-              CoreMatchers.containsString("0"),
-              CoreMatchers.containsString("true")));
-      // expected (3)
-      assertThat(
-          lineAt(e.getMessage(), ++i),
-          CoreMatchers.allOf(
+              CoreMatchers.containsString("Mismatch>:"),
               CoreMatchers.containsString("anyMatch"),
               CoreMatchers.containsString("curry"),
               CoreMatchers.containsString("isNull"),
@@ -187,23 +179,6 @@ public class DbCCurriedFunctionsTest extends TestBase {
               CoreMatchers.containsString("hello"),
               CoreMatchers.containsString("toCurriedContext"),
               CoreMatchers.containsString("variables:[hello]")
-          ));
-      // expected (2) -1
-      assertThat(
-          lineAt(e.getMessage(), ++i),
-          CoreMatchers.allOf(
-              CoreMatchers.containsString("variables:[hello]"),
-              CoreMatchers.containsString("check")
-          ));
-      // expected (2) -2
-      assertThat(
-          lineAt(e.getMessage(), i),
-          CoreMatchers.allOf(
-              CoreMatchers.containsString("curry"),
-              CoreMatchers.containsString("isNull"),
-              CoreMatchers.containsString("0"),
-              CoreMatchers.containsString("->"),
-              CoreMatchers.containsString("true")
           ));
       // actual (2) -1
       assertThat(
@@ -253,18 +228,11 @@ public class DbCCurriedFunctionsTest extends TestBase {
           CoreMatchers.allOf(
               CoreMatchers.containsString("nest"),
               CoreMatchers.containsString("\"1\",\"2\",\"o\"")));
-      // expected (3)
-      assertThat(
-          lineAt(e.getMessage(), ++i),
-          CoreMatchers.allOf(
-              CoreMatchers.containsString("allMatch"),
-              CoreMatchers.containsString("curry"),
-              CoreMatchers.containsString("String"),
-              CoreMatchers.containsString("true")));
       // actual (3)
       assertThat(
           lineAt(e.getMessage(), ++i),
           CoreMatchers.allOf(
+              CoreMatchers.containsString("Mismatch>:"),
               CoreMatchers.containsString("allMatch"),
               CoreMatchers.containsString("curry"),
               CoreMatchers.containsString("String"),

--- a/src/test/java/com/github/valid8j/ut/internal/NegateTest.java
+++ b/src/test/java/com/github/valid8j/ut/internal/NegateTest.java
@@ -29,13 +29,6 @@ public class NegateTest extends TestBase {
       MatcherAssert.assertThat(
           simplifyString(lineAt(e.getMessage(), i++)),
           CoreMatchers.equalTo("Value:'' violated: !length <[100]"));
-      // (1)
-      MatcherAssert.assertThat(
-          simplifyString(lineAt(e.getMessage(), i++)),
-          CoreMatchers.allOf(
-              CoreMatchers.containsString("Mismatch<:"),
-              CoreMatchers.containsString("not"),
-              CoreMatchers.containsString("->true")));
       MatcherAssert.assertThat(
           simplifyString(lineAt(e.getMessage(), i++)),
           CoreMatchers.allOf(
@@ -47,13 +40,6 @@ public class NegateTest extends TestBase {
           CoreMatchers.allOf(
               CoreMatchers.containsString("length"),
               CoreMatchers.containsString("->0")));
-      // expected (2)
-      MatcherAssert.assertThat(
-          simplifyString(lineAt(e.getMessage(), i++)),
-          CoreMatchers.allOf(
-              CoreMatchers.containsString("Mismatch<:"),
-              CoreMatchers.containsString("check:<[100]"),
-              CoreMatchers.containsString("->false")));
       // actual (2)
       MatcherAssert.assertThat(
           simplifyString(lineAt(e.getMessage(), i++)),
@@ -73,21 +59,13 @@ public class NegateTest extends TestBase {
           ApplicationException::new);
     } catch (ApplicationException e) {
       e.printStackTrace();
+      int i = 0;
       MatcherAssert.assertThat(
-          simplifyString(lineAt(e.getMessage(), 0)),
+          simplifyString(lineAt(e.getMessage(), i++)),
           CoreMatchers.equalTo("Value:'Hello' violated: !=[Hello]"));
-      // expected (1)
-      MatcherAssert.assertThat(
-          simplifyString(lineAt(e.getMessage(), 1)),
-          CoreMatchers.allOf(
-              CoreMatchers.containsString("Mismatch<:"),
-              CoreMatchers.containsString("'Hello'"),
-              CoreMatchers.containsString("->not:=[Hello]"),
-              CoreMatchers.containsString("->true")
-          ));
       // actual (1)
       MatcherAssert.assertThat(
-          simplifyString(lineAt(e.getMessage(), 2)),
+          simplifyString(lineAt(e.getMessage(), i)),
           CoreMatchers.allOf(
               CoreMatchers.containsString("Mismatch>:"),
               CoreMatchers.containsString("'Hello'"),
@@ -108,20 +86,13 @@ public class NegateTest extends TestBase {
           ApplicationException::new);
     } catch (ApplicationException e) {
       e.printStackTrace();
+      int i = 0;
       MatcherAssert.assertThat(
-          simplifyString(lineAt(e.getMessage(), 0)),
+          simplifyString(lineAt(e.getMessage(), i++)),
           CoreMatchers.equalTo("Value:'Hello' violated: (!=[WORLD]&&alwaysFalse)"));
-      // expected (1)
-      MatcherAssert.assertThat(
-          simplifyString(lineAt(e.getMessage(), 1)),
-          CoreMatchers.allOf(
-              CoreMatchers.containsString("Mismatch<:"),
-              CoreMatchers.containsString("'Hello'"),
-              CoreMatchers.containsString("and"),
-              CoreMatchers.containsString("->true")));
       // actual (1)
       MatcherAssert.assertThat(
-          simplifyString(lineAt(e.getMessage(), 2)),
+          simplifyString(lineAt(e.getMessage(), i++)),
           CoreMatchers.allOf(
               CoreMatchers.containsString("Mismatch>:"),
               CoreMatchers.containsString("'Hello'"),
@@ -129,20 +100,13 @@ public class NegateTest extends TestBase {
               CoreMatchers.containsString("->false")));
       // (2)
       MatcherAssert.assertThat(
-          simplifyString(lineAt(e.getMessage(), 3)),
+          simplifyString(lineAt(e.getMessage(), i++)),
           CoreMatchers.allOf(
               CoreMatchers.containsString("not:=[WORLD]"),
               CoreMatchers.containsString("->true")));
-      // expected (3)
-      MatcherAssert.assertThat(
-          simplifyString(lineAt(e.getMessage(), 4)),
-          CoreMatchers.allOf(
-              CoreMatchers.containsString("Mismatch<:"),
-              CoreMatchers.containsString("alwaysFalse"),
-              CoreMatchers.containsString("->true")));
       // actual (3)
       MatcherAssert.assertThat(
-          simplifyString(lineAt(e.getMessage(), 5)),
+          simplifyString(lineAt(e.getMessage(), i)),
           CoreMatchers.allOf(
               CoreMatchers.containsString("Mismatch>:"),
               CoreMatchers.containsString("alwaysFalse"),

--- a/src/test/java/com/github/valid8j/ut/valuechecker/DefaultValidatorTest.java
+++ b/src/test/java/com/github/valid8j/ut/valuechecker/DefaultValidatorTest.java
@@ -1,19 +1,19 @@
 package com.github.valid8j.ut.valuechecker;
 
-import com.github.valid8j.utils.testbase.TestBase;
 import com.github.valid8j.pcond.forms.Functions;
 import com.github.valid8j.pcond.forms.Predicates;
 import com.github.valid8j.pcond.validator.Validator;
+import com.github.valid8j.utils.testbase.TestBase;
 import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
 import java.util.Objects;
 import java.util.Properties;
 
-import static com.github.valid8j.utils.TestUtils.lineAt;
-import static com.github.valid8j.utils.TestUtils.numLines;
 import static com.github.valid8j.pcond.forms.Functions.length;
 import static com.github.valid8j.pcond.forms.Predicates.*;
+import static com.github.valid8j.utils.TestUtils.lineAt;
+import static com.github.valid8j.utils.TestUtils.numLines;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -32,13 +32,13 @@ public class DefaultValidatorTest extends TestBase {
       throw e;
     }
   }
-
+  
   @Test
   public void withoutEvaluator_conj_thenPass() {
     createAssertionProvider(useEvaluator(newProperties(), false))
         .requireArgument("Hello World, everyone", and(isNotNull(), isEmptyString().negate(), transform(length()).check(gt(10))));
   }
-
+  
   @Test(expected = IllegalArgumentException.class)
   public void withEvaluator_columns100_conj() {
     try {
@@ -49,60 +49,45 @@ public class DefaultValidatorTest extends TestBase {
       throw e;
     }
   }
-
+  
   @Test
   public void withEvaluator_nativePredicate() {
     String value = createAssertionProvider(nameWidth(useEvaluator(newProperties(), true), 100))
         .requireArgument("Hello", v -> v.equals("Hello"));
     assertThat(value, equalTo("Hello"));
   }
-
+  
   @Test(expected = IllegalArgumentException.class)
   public void withEvaluator_disj$or$_thenFail() {
     try {
       createAssertionProvider(nameWidth(useEvaluator(newProperties(), true), 100))
           .requireArgument("Hello",
-              or(                                       // (1)
-                  isEqualTo("hello"),             // (2)
-                  isEqualTo("HELLO")));           // (3)
+                           or(                                       // (1)
+                                                                     isEqualTo("hello"),             // (2)
+                                                                     isEqualTo("HELLO")));           // (3)
     } catch (IllegalArgumentException e) {
       e.printStackTrace();
-      // expected (1)
-      assertThat(lineAt(e.getMessage(), 1), allOf(
-          CoreMatchers.containsString("or"),
-          CoreMatchers.containsString("->"),
-          CoreMatchers.containsString("true")
-
-      ));
+      int i = 1;
+      
       // actual (1)
-      assertThat(lineAt(e.getMessage(), 2), allOf(
+      assertThat(lineAt(e.getMessage(), i++), allOf(
+          CoreMatchers.containsString("Mismatch>:"),
           CoreMatchers.containsString("or"),
           CoreMatchers.containsString("->"),
           CoreMatchers.containsString("false")
-
-      ));
-      // expected (2)
-      assertThat(lineAt(e.getMessage(), 3), allOf(
-          CoreMatchers.containsString("isEqualTo[hello]"),
-          CoreMatchers.containsString("->"),
-          CoreMatchers.containsString("true")
-
+      
       ));
       // actual (2)
-      assertThat(lineAt(e.getMessage(), 4), allOf(
+      assertThat(lineAt(e.getMessage(), i++), allOf(
+          CoreMatchers.containsString("Mismatch>:"),
           CoreMatchers.containsString("isEqualTo[hello]"),
           CoreMatchers.containsString("->"),
           CoreMatchers.containsString("false")
-
-      ));
-      // expected (3)
-      assertThat(lineAt(e.getMessage(), 5), allOf(
-          CoreMatchers.containsString("  isEqualTo[HELLO]"),
-          CoreMatchers.containsString("->"),
-          CoreMatchers.containsString("true")
+      
       ));
       // actual (3)
-      assertThat(lineAt(e.getMessage(), 6), allOf(
+      assertThat(lineAt(e.getMessage(), i), allOf(
+          CoreMatchers.containsString("Mismatch>:"),
           CoreMatchers.containsString("  isEqualTo[HELLO]"),
           CoreMatchers.containsString("->"),
           CoreMatchers.containsString("false")
@@ -110,25 +95,20 @@ public class DefaultValidatorTest extends TestBase {
       throw e;
     }
   }
-
+  
   @Test(expected = IllegalArgumentException.class)
   public void withEvaluator_disj$anyOf$_thenFail() {
     try {
       createAssertionProvider(nameWidth(useEvaluator(newProperties(), true), 100))
           .requireArgument("Hello",
-              anyOf(                               // (1)
-                  isEqualTo("hello"),
-                  isEqualTo("HELLO")));
+                           anyOf(                               // (1)
+                                                                isEqualTo("hello"),
+                                                                isEqualTo("HELLO")));
     } catch (IllegalArgumentException e) {
       e.printStackTrace();
-      // expected (1)
-      assertThat(lineAt(e.getMessage(), 1), allOf(
-          CoreMatchers.containsString("anyOf"),
-          CoreMatchers.containsString("->"),
-          CoreMatchers.containsString("true")
-      ));
       //actual (1)
-      assertThat(lineAt(e.getMessage(), 2), allOf(
+      assertThat(lineAt(e.getMessage(), 1), allOf(
+          CoreMatchers.containsString("Mismatch>:"),
           CoreMatchers.containsString("anyOf"),
           CoreMatchers.containsString("->"),
           CoreMatchers.containsString("false")
@@ -136,15 +116,15 @@ public class DefaultValidatorTest extends TestBase {
       throw e;
     }
   }
-
+  
   @Test(expected = IllegalArgumentException.class)
   public void withEvaluator_transforming_thenFail() {
     try {
       createAssertionProvider(nameWidth(useEvaluator(newProperties(), true), 100))
           .requireArgument("Hello",
-              transform(Functions.length())                    // (1)
-                  .check(                                      // (2) - 1
-                      Predicates.gt(10)));               // (2) - 2
+                           transform(Functions.length())                    // (1)
+                                                                            .check(                                      // (2) - 1
+                                                                                                                         Predicates.gt(10)));               // (2) - 2
     } catch (IllegalArgumentException e) {
       e.printStackTrace(System.out);
       int i = 0;
@@ -153,25 +133,20 @@ public class DefaultValidatorTest extends TestBase {
           CoreMatchers.containsString("length"),
           CoreMatchers.containsString("->"),
           CoreMatchers.containsString("5")
-
+      
       ));
       // (2) - 1
       assertThat(lineAt(e.getMessage(), ++i),
-          CoreMatchers.containsString("check"));
-      // expected (2) - 2
-      assertThat(lineAt(e.getMessage(), i), allOf(
-          CoreMatchers.containsString(">[10]"),
-          CoreMatchers.containsString("->"),
-          CoreMatchers.containsString("true")));
-      // actual (2) - 2
-      assertThat(lineAt(e.getMessage(), ++i), allOf(
-          CoreMatchers.containsString(">[10]"),
-          CoreMatchers.containsString("->"),
-          CoreMatchers.containsString("false")));
+                 allOf(
+                     CoreMatchers.containsString("Mismatch>:"),
+                     CoreMatchers.containsString("check"),
+                     CoreMatchers.containsString(">[10]"),
+                     CoreMatchers.containsString("->"),
+                     CoreMatchers.containsString("false")));
       throw e;
     }
   }
-
+  
   @Test
   public void withEvaluator_disj_thenPass() {
     try {
@@ -182,7 +157,7 @@ public class DefaultValidatorTest extends TestBase {
       throw e;
     }
   }
-
+  
   /**
    * Expected message:
    * <pre>
@@ -196,54 +171,39 @@ public class DefaultValidatorTest extends TestBase {
     try {
       createAssertionProvider(nameWidth(useEvaluator(newProperties(), true), 100))
           .requireArgument(null,
-              and(                                              // (1)
-                  isNotNull(),                                  // (2)
-                  isEmptyString().negate(),
-                  transform(length()).check(gt(10))));
+                           and(                                              // (1)
+                                                                             isNotNull(),                                  // (2)
+                                                                             isEmptyString().negate(),
+                                                                             transform(length()).check(gt(10))));
     } catch (IllegalArgumentException e) {
       e.printStackTrace();
-      // expected (1)
-      assertThat(lineAt(e.getMessage(), 1), allOf(
-          CoreMatchers.containsString("Mismatch<:"),
-          CoreMatchers.containsString("and"),
-          CoreMatchers.containsString("->true")
-
-      ));
+      int i = 1;
       // actual (1)
-      assertThat(lineAt(e.getMessage(), 2), allOf(
+      assertThat(lineAt(e.getMessage(), i++), allOf(
           CoreMatchers.containsString("Mismatch>:"),
           CoreMatchers.containsString("and"),
           CoreMatchers.containsString("->false")
-
-      ));
-      // expected (2)
-      assertThat(lineAt(e.getMessage(), 3), allOf(
-          CoreMatchers.containsString("Mismatch<:"),
-          CoreMatchers.containsString("isNotNull"),
-          CoreMatchers.containsString("->true")
-
+      
       ));
       // actual (2)
-      assertThat(lineAt(e.getMessage(), 4), allOf(
+      assertThat(lineAt(e.getMessage(), i), allOf(
           CoreMatchers.containsString("Mismatch>:"),
           CoreMatchers.containsString("isNotNull"),
           CoreMatchers.containsString("->false")
-
+      
       ));
       throw e;
     }
   }
-
+  
   /**
    * Expected message:
    * ----
    * java.lang.IllegalArgumentException: value:"hello" violated precondition:value (isNotNull&&!isEmpty&&length >[10])
-   * Mismatch<:"hello"->and               ->true                 // (1)
    * Mismatch>:"hello"->and               ->false                // (1)
    * isNotNull       ->true                 // (2)
    * not(isEmpty)    ->true                 // (3)
    * transform:length->5                    // (4)
-   * Mismatch<:5      ->  check:>[10]     ->true                 // (5)
    * Mismatch>:5      ->  check:>[10]     ->false                // (5)
    * ----
    */
@@ -252,82 +212,67 @@ public class DefaultValidatorTest extends TestBase {
     try {
       createAssertionProvider(nameWidth(useEvaluator(newProperties(), true), 100))
           .requireArgument("hello",
-              and(                                                // (1)
-                  isNotNull(),                                    // (2)
-                  isEmptyString().negate(),                       // (3)
-                  transform(length())                             // (4)
-                      .check(gt(10))));                     // (5)
+                           and(                                                // (1)
+                                                                               isNotNull(),                                    // (2)
+                                                                               isEmptyString().negate(),                       // (3)
+                                                                               transform(length())                             // (4)
+                                                                                                                               .check(gt(10))));                     // (5)
     } catch (IllegalArgumentException e) {
       e.printStackTrace();
-      // expected (1)
-      assertThat(lineAt(e.getMessage(), 1), allOf(
-          CoreMatchers.containsString("Mismatch<:"),
-          CoreMatchers.containsString("and"),
-          CoreMatchers.containsString("->true")
-
-      ));
+      int i = 1;
       // actual (1)
-      assertThat(lineAt(e.getMessage(), 2), allOf(
+      assertThat(lineAt(e.getMessage(), i++), allOf(
           CoreMatchers.containsString("Mismatch>:"),
           CoreMatchers.containsString("and"),
           CoreMatchers.containsString("->false")
-
+      
       ));
       // (2)
-      assertThat(lineAt(e.getMessage(), 3), allOf(
+      assertThat(lineAt(e.getMessage(), i++), allOf(
           CoreMatchers.not(CoreMatchers.containsString("Mismatch:")),
           CoreMatchers.containsString("isNotNull"),
           CoreMatchers.containsString("->true")
-
+      
       ));
       // (3)
-      assertThat(lineAt(e.getMessage(), 4), allOf(
+      assertThat(lineAt(e.getMessage(), i++), allOf(
           CoreMatchers.not(CoreMatchers.containsString("Mismatch:")),
           CoreMatchers.containsString("not:isEmpty"),
           CoreMatchers.containsString("->true")
-
+      
       ));
       // (4)
-      assertThat(lineAt(e.getMessage(), 5), allOf(
-          CoreMatchers.not(CoreMatchers.containsString("Mismatch:")),
+      assertThat(lineAt(e.getMessage(), i++), allOf(
+          CoreMatchers.not(CoreMatchers.containsString("Mismatch")),
           CoreMatchers.containsString("length"),
           CoreMatchers.containsString("->5")
-
-      ));
-      // expected (5)
-      assertThat(lineAt(e.getMessage(), 6), allOf(
-          CoreMatchers.containsString("Mismatch<:"),
-          CoreMatchers.containsString("check:"),
-          CoreMatchers.containsString(">[10]"),
-          CoreMatchers.containsString("->true")
-
+      
       ));
       // actual (5)
-      assertThat(lineAt(e.getMessage(), 7), allOf(
+      assertThat(lineAt(e.getMessage(), i), allOf(
           CoreMatchers.containsString("Mismatch>:"),
           CoreMatchers.containsString("check:"),
           CoreMatchers.containsString(">[10]"),
           CoreMatchers.containsString("->false")
-
       ));
       throw e;
     }
   }
-
+  
   public Validator.Impl createAssertionProvider(Properties properties) {
     return new Validator.Impl(Validator.configurationFromProperties(properties));
   }
-
+  
   public static Properties useEvaluator(Properties properties, boolean useEvaluator) {
     properties.setProperty("useEvaluator", Objects.toString(useEvaluator));
     return properties;
   }
-
+  
   public static Properties nameWidth(Properties properties, int columns) {
     properties.setProperty("summarizedStringLength", Objects.toString(columns));
     return properties;
   }
-
+  
   public static Properties newProperties() {
     return new Properties();
   }


### PR DESCRIPTION
Currently, it gives almost the same message twice:

- Mismatch<:condition which was broken=true <-- expect 
- Mismatch>:condition which was broken=false <-- actual 

Just printing actual is enough.