### PR TITLE
Squash StackTrace on a Failure

### DIFF
--- a/src/main/java/com/github/valid8j/fluent/Expectations.java
+++ b/src/main/java/com/github/valid8j/fluent/Expectations.java
@@ -80,10 +80,10 @@ public enum Expectations {
 
   /**
    * Checks if all the given `statements` are satisfied.
-   * <p>
+   *
    * Otherwise, this method throws an exception whose message describes what happened (how expectations are not satisfied.)
    * This method is supposed to be used with `assert` statement of Java and when:
-   * <p>
+   *
    * - yor are checking invariant conditions in DbC ("Design by Contract") approach.
    * - you are not interested in DbC approach.
    *
@@ -96,10 +96,10 @@ public enum Expectations {
 
   /**
    * A "singular" version of {@link Expectations#all(Statement[])}.
-   * <p>
+   *
    * Prefer this method if you only have one statement to be asserted.
    * This method is supposed to be used with `assert` statement of Java and when:
-   * <p>
+   *
    * - yor are checking invariant conditions in DbC ("Design by Contract") approach.
    * - you are not interested in DbC approach.
    *
@@ -113,7 +113,7 @@ public enum Expectations {
 
   /**
    * Checks if all the given `statements` are satisfied.
-   * <p>
+   *
    * Otherwise, this method throws an exception whose message describes what happened (how expectations are not satisfied.)
    * This method is supposed to be used with `assert` statement of Java and when yor are checking preconditions in DbC ("Design by Contract") approach.
    *
@@ -126,7 +126,7 @@ public enum Expectations {
 
   /**
    * A "singular" version of {@link Expectations#preconditions(Statement[])}.
-   * <p>
+   *
    * Use this method if you only have one statement to be asserted.
    * This method is supposed to be used with `assert` statement of Java and when yor are checking a precondition in DbC ("Design by Contract") approach.
    *
@@ -140,7 +140,7 @@ public enum Expectations {
 
   /**
    * Checks if all the given `statements` are satisfied.
-   * <p>
+   *
    * Otherwise, this method throws an exception whose message describes what happened (how expectations are not satisfied.)
    * This method is supposed to be used with `assert` statement of Java and when yor are checking preconditions in DbC ("Design by Contract") approach.
    *
@@ -153,7 +153,7 @@ public enum Expectations {
 
   /**
    * A singular version of {@link Expectations#preconditions(Statement[])}.
-   * <p>
+   *
    * Use this method if you only have one statement to be asserted.
    * This method is supposed to be used with `assert` statement of Java and when yor are checking a precondition in DbC ("Design by Contract") approach.
    *
@@ -167,7 +167,7 @@ public enum Expectations {
 
   /**
    * Checks if all the given `statements` are satisfied.
-   * <p>
+   *
    * Otherwise, this method throws an exception whose message describes what happened (how expectations are not satisfied.)
    * This method is supposed to be used with `assert` statement of Java and when yor are checking post-conditions in DbC ("Design by Contract") approach.
    *
@@ -181,7 +181,7 @@ public enum Expectations {
 
   /**
    * A singular version of {@link Expectations#postconditions(Statement[])}.
-   * <p>
+   *
    * Use this method if you only have one statement to be asserted.
    * This method is supposed to be used with `assert` statement of Java and when yor are checking a post-condition in DbC ("Design by Contract") approach.
    *
@@ -861,7 +861,7 @@ public enum Expectations {
   /**
    * Fluent version of {@link TestAssertions#assertThat(Object, Predicate)}.
    * Use this method when you need to verify multiple values.
-   * <p>
+   *
    * You can use {@link Expectations#assertStatement(Statement)}, if you have only one statement to be verified, for readability's sake.
    *
    * @param statements Statements to be verified
@@ -884,7 +884,7 @@ public enum Expectations {
   /**
    * Fluent version of {@link TestAssertions#assumeThat(Object, Predicate)}.
    * Use this method when you need to verify multiple values.
-   * <p>
+   *
    * You can use {@link Expectations#assumeStatement(Statement)}}, if you have only one statement to be verified, for readability's sake.
    *
    * @param statements Statements to be verified

--- a/src/main/java/com/github/valid8j/fluent/Expectations.java
+++ b/src/main/java/com/github/valid8j/fluent/Expectations.java
@@ -8,6 +8,7 @@ import com.github.valid8j.pcond.core.fluent.Checker;
 import com.github.valid8j.pcond.core.fluent.Matcher;
 import com.github.valid8j.pcond.core.fluent.Transformer;
 import com.github.valid8j.pcond.core.fluent.builtins.*;
+import com.github.valid8j.pcond.core.refl.Parameter;
 import com.github.valid8j.pcond.fluent.ListHolder;
 import com.github.valid8j.pcond.fluent.Statement;
 import com.github.valid8j.pcond.forms.Functions;
@@ -79,10 +80,10 @@ public enum Expectations {
 
   /**
    * Checks if all the given `statements` are satisfied.
-   *
+   * <p>
    * Otherwise, this method throws an exception whose message describes what happened (how expectations are not satisfied.)
    * This method is supposed to be used with `assert` statement of Java and when:
-   *
+   * <p>
    * - yor are checking invariant conditions in DbC ("Design by Contract") approach.
    * - you are not interested in DbC approach.
    *
@@ -95,10 +96,10 @@ public enum Expectations {
 
   /**
    * A "singular" version of {@link Expectations#all(Statement[])}.
-   *
+   * <p>
    * Prefer this method if you only have one statement to be asserted.
    * This method is supposed to be used with `assert` statement of Java and when:
-   *
+   * <p>
    * - yor are checking invariant conditions in DbC ("Design by Contract") approach.
    * - you are not interested in DbC approach.
    *
@@ -112,7 +113,7 @@ public enum Expectations {
 
   /**
    * Checks if all the given `statements` are satisfied.
-   *
+   * <p>
    * Otherwise, this method throws an exception whose message describes what happened (how expectations are not satisfied.)
    * This method is supposed to be used with `assert` statement of Java and when yor are checking preconditions in DbC ("Design by Contract") approach.
    *
@@ -125,7 +126,7 @@ public enum Expectations {
 
   /**
    * A "singular" version of {@link Expectations#preconditions(Statement[])}.
-   *
+   * <p>
    * Use this method if you only have one statement to be asserted.
    * This method is supposed to be used with `assert` statement of Java and when yor are checking a precondition in DbC ("Design by Contract") approach.
    *
@@ -139,7 +140,7 @@ public enum Expectations {
 
   /**
    * Checks if all the given `statements` are satisfied.
-   *
+   * <p>
    * Otherwise, this method throws an exception whose message describes what happened (how expectations are not satisfied.)
    * This method is supposed to be used with `assert` statement of Java and when yor are checking preconditions in DbC ("Design by Contract") approach.
    *
@@ -152,7 +153,7 @@ public enum Expectations {
 
   /**
    * A singular version of {@link Expectations#preconditions(Statement[])}.
-   *
+   * <p>
    * Use this method if you only have one statement to be asserted.
    * This method is supposed to be used with `assert` statement of Java and when yor are checking a precondition in DbC ("Design by Contract") approach.
    *
@@ -166,7 +167,7 @@ public enum Expectations {
 
   /**
    * Checks if all the given `statements` are satisfied.
-   *
+   * <p>
    * Otherwise, this method throws an exception whose message describes what happened (how expectations are not satisfied.)
    * This method is supposed to be used with `assert` statement of Java and when yor are checking post-conditions in DbC ("Design by Contract") approach.
    *
@@ -180,7 +181,7 @@ public enum Expectations {
 
   /**
    * A singular version of {@link Expectations#postconditions(Statement[])}.
-   *
+   * <p>
    * Use this method if you only have one statement to be asserted.
    * This method is supposed to be used with `assert` statement of Java and when yor are checking a post-condition in DbC ("Design by Contract") approach.
    *
@@ -627,6 +628,15 @@ public enum Expectations {
   }
 
   /**
+   * Returns a place holder object useful for `invokeStatic` method.
+   *
+   * @return A place holder object.
+   */
+  public static Object parameter() {
+    return Parameter.INSTANCE;
+  }
+
+  /**
    * Returns a checker to build a statement for the given `value`.
    * The checker is created by the given `checkerFactory` function.
    *
@@ -851,7 +861,7 @@ public enum Expectations {
   /**
    * Fluent version of {@link TestAssertions#assertThat(Object, Predicate)}.
    * Use this method when you need to verify multiple values.
-   *
+   * <p>
    * You can use {@link Expectations#assertStatement(Statement)}, if you have only one statement to be verified, for readability's sake.
    *
    * @param statements Statements to be verified
@@ -874,7 +884,7 @@ public enum Expectations {
   /**
    * Fluent version of {@link TestAssertions#assumeThat(Object, Predicate)}.
    * Use this method when you need to verify multiple values.
-   *
+   * <p>
    * You can use {@link Expectations#assumeStatement(Statement)}}, if you have only one statement to be verified, for readability's sake.
    *
    * @param statements Statements to be verified

--- a/src/main/java/com/github/valid8j/pcond/validator/Validator.java
+++ b/src/main/java/com/github/valid8j/pcond/validator/Validator.java
@@ -293,7 +293,7 @@ public interface Validator {
 
   /**
    * A method to check if a `value` satisfies a predicate `cond`.
-   * <p>
+   *
    * This method is intended to be used by {@code Assertions#that(Object, Predicate)} in valid8j library.
    * If the condition is not satisfied, an exception created by `this.exceptionComposer().forAssert().exceptionInvariantConditionViolation()`
    * method will be thrown.
@@ -312,7 +312,7 @@ public interface Validator {
 
   /**
    * A method to check if a `value` satisfies a predicate `cond`.
-   * <p>
+   *
    * This method is intended to be used by {@code Assertions#precondition(Object, Predicate)} in valid8j library.
    * If the condition is not satisfied, an exception created by `this.exceptionComposer().forAssert().exceptionPreconditionViolation()`
    * method will be thrown.
@@ -331,7 +331,7 @@ public interface Validator {
 
   /**
    * A method to check if a `value` satisfies a predicate `cond`.
-   * <p>
+   *
    * This method is intended to be used by {@code Assertions#postcondition(Object, Predicate)} in valid8j library.
    * If the condition is not satisfied, an exception created by `this.exceptionComposer().forAssert().exceptionPostconditionViolation()`
    * method will be thrown.

--- a/src/main/java/com/github/valid8j/pcond/validator/Validator.java
+++ b/src/main/java/com/github/valid8j/pcond/validator/Validator.java
@@ -462,11 +462,11 @@ public interface Validator {
     }
 
     static RuntimeException createException(ExceptionFactory<?> exceptionFactory, Explanation explanation) {
-      Throwable t = exceptionFactory.apply(explanation);
-      if (squashStackTraceElements(t) instanceof Error)
-        throw (Error) squashStackTraceElements(t);
-      if (squashStackTraceElements(t) instanceof RuntimeException)
-        throw (RuntimeException) squashStackTraceElements(t);
+      Throwable t = squashStackTraceElements(exceptionFactory.apply(explanation));
+      if (t instanceof Error)
+        throw (Error) t;
+      if (t instanceof RuntimeException)
+        throw (RuntimeException) t;
       throw new AssertionError(format("Checked exception(%s) cannot be used for validation.", squashStackTraceElements(t).getClass()), squashStackTraceElements(t));
     }
   }

--- a/src/main/java/com/github/valid8j/pcond/validator/Validator.java
+++ b/src/main/java/com/github/valid8j/pcond/validator/Validator.java
@@ -6,20 +6,17 @@ import com.github.valid8j.pcond.internals.InternalUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Properties;
+import java.util.*;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
 
-import static com.github.valid8j.pcond.internals.InternalUtils.toEvaluableIfNecessary;
-import static java.lang.String.format;
-import static java.util.Collections.emptyList;
 import static com.github.valid8j.pcond.validator.Validator.Configuration.Utils.instantiate;
 import static com.github.valid8j.pcond.validator.Validator.Configuration.Utils.loadPcondProperties;
+import static java.lang.String.format;
+import static java.util.Collections.emptyList;
 
 /**
  * An interface of a policy for behaviours on 'contract violations'.
@@ -120,7 +117,7 @@ public interface Validator {
         value,
         cond,
         this.configuration().messageComposer()::composeMessageForPrecondition,
-        explanation -> exceptionFactory.apply(explanation.toString()));
+        explanation -> squashStackTraceElements(exceptionFactory.apply(explanation.toString())));
   }
 
   /**
@@ -208,7 +205,17 @@ public interface Validator {
    * @return The value itself.
    */
   default <T> T validate(T value, Predicate<? super T> cond, Function<String, Throwable> exceptionFactory) {
-    return validate_2(value, cond, explanation -> exceptionFactory.apply(explanation.toString()));
+    return validate_2(value, cond, explanation -> squashStackTraceElements(exceptionFactory.apply(explanation.toString())));
+  }
+
+  static Throwable squashStackTraceElements(Throwable throwable) {
+    StackTraceElement[] stackTraceElements = throwable.getStackTrace();
+    StackTraceElement first = stackTraceElements[0];
+    throwable.setStackTrace(Stream.concat(Stream.of(new StackTraceElement(first.getClassName(), "STACKTRACE_WAS_SQUASHED", first.getFileName(), first.getLineNumber())),
+                                      Arrays.stream(stackTraceElements)
+                                            .filter(e -> !e.getClassName().startsWith("com.github.valid8j.")))
+                                  .toArray(StackTraceElement[]::new));
+    return throwable;
   }
 
   default <T> T validate_2(T value, Predicate<? super T> cond, ExceptionFactory<Throwable> exceptionFactory) {
@@ -281,12 +288,12 @@ public interface Validator {
         value,
         cond,
         configuration().messageComposer()::composeMessageForPostcondition,
-        explanation -> exceptionComposer.apply(explanation.toString()));
+        explanation -> squashStackTraceElements(exceptionComposer.apply(explanation.toString())));
   }
 
   /**
    * A method to check if a `value` satisfies a predicate `cond`.
-   *
+   * <p>
    * This method is intended to be used by {@code Assertions#that(Object, Predicate)} in valid8j library.
    * If the condition is not satisfied, an exception created by `this.exceptionComposer().forAssert().exceptionInvariantConditionViolation()`
    * method will be thrown.
@@ -305,7 +312,7 @@ public interface Validator {
 
   /**
    * A method to check if a `value` satisfies a predicate `cond`.
-   *
+   * <p>
    * This method is intended to be used by {@code Assertions#precondition(Object, Predicate)} in valid8j library.
    * If the condition is not satisfied, an exception created by `this.exceptionComposer().forAssert().exceptionPreconditionViolation()`
    * method will be thrown.
@@ -324,7 +331,7 @@ public interface Validator {
 
   /**
    * A method to check if a `value` satisfies a predicate `cond`.
-   *
+   * <p>
    * This method is intended to be used by {@code Assertions#postcondition(Object, Predicate)} in valid8j library.
    * If the condition is not satisfied, an exception created by `this.exceptionComposer().forAssert().exceptionPostconditionViolation()`
    * method will be thrown.
@@ -456,11 +463,11 @@ public interface Validator {
 
     static RuntimeException createException(ExceptionFactory<?> exceptionFactory, Explanation explanation) {
       Throwable t = exceptionFactory.apply(explanation);
-      if (t instanceof Error)
-        throw (Error) t;
-      if (t instanceof RuntimeException)
-        throw (RuntimeException) t;
-      throw new AssertionError(format("Checked exception(%s) cannot be used for validation.", t.getClass()), t);
+      if (squashStackTraceElements(t) instanceof Error)
+        throw (Error) squashStackTraceElements(t);
+      if (squashStackTraceElements(t) instanceof RuntimeException)
+        throw (RuntimeException) squashStackTraceElements(t);
+      throw new AssertionError(format("Checked exception(%s) cannot be used for validation.", squashStackTraceElements(t).getClass()), squashStackTraceElements(t));
     }
   }
 
@@ -560,15 +567,15 @@ public interface Validator {
 
     class Builder implements Cloneable {
       boolean useEvaluator;
-      int     summarizedStringLength;
+      int summarizedStringLength;
 
 
       MessageComposer messageComposer;
       ReportComposer reportComposer;
-      private ExceptionComposer.ForRequire       exceptionComposerForRequire;
-      private ExceptionComposer.ForEnsure        exceptionComposerForEnsure;
-      private ExceptionComposer.ForValidate      defaultExceptionComposerForValidate;
-      private ExceptionComposer.ForAssertion     exceptionComposerForAssert;
+      private ExceptionComposer.ForRequire exceptionComposerForRequire;
+      private ExceptionComposer.ForEnsure exceptionComposerForEnsure;
+      private ExceptionComposer.ForValidate defaultExceptionComposerForValidate;
+      private ExceptionComposer.ForAssertion exceptionComposerForAssert;
       private ExceptionComposer.ForTestAssertion exceptionComposerForTestFailures;
 
       public Builder() {

--- a/src/main/java/com/github/valid8j/pcond/validator/Validator.java
+++ b/src/main/java/com/github/valid8j/pcond/validator/Validator.java
@@ -144,7 +144,7 @@ public interface Validator {
    * Otherwise, an exception created by `forValidate.exceptionForGeneralViolation()`
    * will be thrown.
    * This method is intended to be used by {@code Validates#validateNonNull(Object)}
-   * method in valid8j library.
+   * method in the **valid8j** library.
    *
    * @param value       The value to be checked.
    * @param forValidate An exception composer for "validate" methods.
@@ -196,7 +196,7 @@ public interface Validator {
    * If the value satisfies a condition `cond`, the value itself will be returned.
    * Otherwise, an exception created by `exceptionFactory` will be thrown.
    * This method is intended to be used by {@code Validates#validate(Object, Predicate, Function)}
-   * method in valid8j library.
+   * method in the **valid8j** library.
    *
    * @param value            The value to be checked.
    * @param cond             A condition to validate the `value`.
@@ -467,7 +467,7 @@ public interface Validator {
         throw (Error) t;
       if (t instanceof RuntimeException)
         throw (RuntimeException) t;
-      throw new AssertionError(format("Checked exception(%s) cannot be used for validation.", squashStackTraceElements(t).getClass()), squashStackTraceElements(t));
+      throw new AssertionError(format("Checked exception(%s) cannot be used for validation.", t.getClass()), t);
     }
   }
 

--- a/src/test/java/com/github/valid8j/entrypoints/AssertionsTest.java
+++ b/src/test/java/com/github/valid8j/entrypoints/AssertionsTest.java
@@ -10,6 +10,7 @@ import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 
 import java.util.Properties;
+import java.util.function.Function;
 
 import static org.junit.Assert.assertEquals;
 
@@ -155,6 +156,15 @@ public class AssertionsTest {
     @Test
     public void composeMessage$thenComposed() {
       assertEquals("Value:\"hello\" violated: isNull", new Validator.Impl(Validator.configurationFromProperties(new Properties())).configuration().messageComposer().composeMessageForAssertion("hello", Predicates.isNull()));
+    }
+
+    @Test
+    public void givenLambda$whenPreconditionExercised_thenTrueReturned() {
+      try {
+        assertTrue(Assertions.that((Function<String, Integer>)((String v) -> 2), Predicates.not(Predicates.isEqualTo(1))));
+      } catch (AssertionError e) {
+        throw new ExpectedException(e);
+      }
     }
   }
 

--- a/src/test/java/com/github/valid8j/ut/NullValueHandlingTest.java
+++ b/src/test/java/com/github/valid8j/ut/NullValueHandlingTest.java
@@ -1,0 +1,31 @@
+package com.github.valid8j.ut;
+
+import com.github.valid8j.classic.TestAssertions;
+import com.github.valid8j.fluent.Expectations;
+import com.github.valid8j.pcond.forms.Predicates;
+import org.junit.ComparisonFailure;
+import org.junit.Test;
+
+/**
+ * // @formatter:off 
+ * // @formatter:on 
+ */
+public class NullValueHandlingTest {
+  @Test(expected = ComparisonFailure.class)
+  public void givenNull_whenStatementIsExamined_thenProcessedCorrectly() {
+    Expectations.assertStatement(Expectations.value((String) null).toBe().equalTo("hello"));
+  }
+
+
+  @Test(expected = ComparisonFailure.class)
+  public void givenNull_whenStatementIsExamined_thenProcessedCorrectly2() {
+    Expectations.assertStatement(Expectations.value((String) null)
+                                             .toBe()
+                                             .predicate(Predicates.and(Predicates.isNotNull(), Predicates.equalTo("Hello"))));
+  }
+
+  @Test(expected = ComparisonFailure.class)
+  public void givenNull_whenStatementIsExamined_thenProcessedCorrectly3() {
+    TestAssertions.assertThat((String)null, Predicates.and(Predicates.isNotNull(), Predicates.equalTo("Hello")));
+  }
+}


### PR DESCRIPTION
* Add `parameter` method to `Expectations` for easy use.
* Clean up JavaDoc a bit.
