### PR TITLE
fix: Rectify method/field names of 'trivial'

### DIFF
--- a/src/main/java/com/github/valid8j/metamor/IoContext.java
+++ b/src/main/java/com/github/valid8j/metamor/IoContext.java
@@ -58,7 +58,7 @@ public interface IoContext<I, O> {
 
     public static <I, O> Function<Ongoing<I, O>, IoContext<I, O>> toCloseFunction(String contextName) {
       // close
-      return ((PrintableFunction<Ongoing<I, O>, IoContext<I, O>>) Printables.<Ongoing<I, O>, IoContext<I, O>>function(() -> "end:" + contextName, Ongoing::close)).makeTrivial();
+      return ((PrintableFunction<Ongoing<I, O>, IoContext<I, O>>) Printables.<Ongoing<I, O>, IoContext<I, O>>function(() -> "end:" + contextName, Ongoing::close)).markSquashable();
     }
 
     public static <I, O> Function<IoContext<I, O>, Dataset<O>> toOutputExtractorFunction(String contextName) {

--- a/src/main/java/com/github/valid8j/pcond/core/Evaluable.java
+++ b/src/main/java/com/github/valid8j/pcond/core/Evaluable.java
@@ -43,7 +43,7 @@ public interface Evaluable<T> {
     return false;
   }
 
-  default Evaluable<T> makeTrivial() {
+  default Evaluable<T> markSquashable() {
     throw new UnsupportedOperationException();
   }
 

--- a/src/main/java/com/github/valid8j/pcond/core/printable/PrintableFunction.java
+++ b/src/main/java/com/github/valid8j/pcond/core/printable/PrintableFunction.java
@@ -23,7 +23,7 @@ public class PrintableFunction<T, R> extends
   private final Supplier<String>                 formatter;
   private final Function<?, R>                   tailAsFunction;
 
-  boolean trivial = false;
+  boolean squashable = false;
 
   @SuppressWarnings("unchecked")
   protected PrintableFunction(Object creator, List<Object> args, Supplier<String> s, Function<? super T, ? extends R> function, Function<? super T, ?> head, Evaluable<?> tail) {
@@ -122,13 +122,13 @@ public class PrintableFunction<T, R> extends
 
 
   public boolean isSquashable() {
-    return this.trivial;
+    return this.squashable;
   }
 
   @Override
-  public PrintableFunction<T, R> makeTrivial() {
+  public PrintableFunction<T, R> markSquashable() {
     PrintableFunction<T, R> ret = this.clone();
-    ret.trivial = true;
+    ret.squashable = true;
     return ret;
   }
 

--- a/src/main/java/com/github/valid8j/pcond/core/printable/PrintablePredicate.java
+++ b/src/main/java/com/github/valid8j/pcond/core/printable/PrintablePredicate.java
@@ -71,7 +71,7 @@ public abstract class PrintablePredicate<T> extends Identifiable.Base implements
   }
 
   @Override
-  public PrintablePredicate<T> makeTrivial() {
+  public PrintablePredicate<T> markSquashable() {
     PrintablePredicate<T> ret = this.clone();
     ret.squashable = true;
     return ret;

--- a/src/main/java/com/github/valid8j/pcond/fluent/Statement.java
+++ b/src/main/java/com/github/valid8j/pcond/fluent/Statement.java
@@ -10,6 +10,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
+import static com.github.valid8j.pcond.forms.Functions.elementAt;
 import static com.github.valid8j.pcond.forms.Predicates.allOf;
 import static com.github.valid8j.pcond.forms.Predicates.transform;
 import static com.github.valid8j.pcond.internals.InternalUtils.makeSquashable;
@@ -30,9 +31,9 @@ public interface Statement<T> {
   static Predicate<? super List<?>> createPredicateForAllOf(Statement<?>[] statements) {
     AtomicInteger i = new AtomicInteger(0);
     @SuppressWarnings("unchecked") Predicate<? super List<?>>[] predicates = Arrays.stream(statements)
-        .map(e -> makeSquashable(transform(Functions.elementAt(i.getAndIncrement())).check("WHEN", (Predicate<? super Object>) e.statementPredicate())))
+        .map(e -> (transform(elementAt(i.getAndIncrement())).check("WHEN", (Predicate<? super Object>) e.statementPredicate())))
         .toArray(Predicate[]::new);
-    return makeSquashable(allOf(predicates));
+    return (allOf(predicates));
   }
 
   /**

--- a/src/main/java/com/github/valid8j/pcond/internals/InternalUtils.java
+++ b/src/main/java/com/github/valid8j/pcond/internals/InternalUtils.java
@@ -310,4 +310,43 @@ public enum InternalUtils {
   public static <T> Function<T, T> trivialIdentityFunction() {
     return Functions.identity();
   }
+
+  public static int estimateWidth(String text) {
+    int width = 0;
+
+    for (char ch : text.toCharArray()) {
+      if (isFullWidth(ch)) {
+        width += 2; // Full-width character
+      } else {
+        width += 1; // Half-width character
+      }
+    }
+
+    return width;
+  }
+
+  private static boolean isFullWidth(char ch) {
+    int codePoint = (int) ch;
+
+    // Unicode ranges for full-width characters
+    return (codePoint >= 0x1100 && codePoint <= 0x115F) || // Hangul Jamo
+           (codePoint >= 0x2E80 && codePoint <= 0xA4CF) || // CJK, Yi, and others
+           (codePoint >= 0xAC00 && codePoint <= 0xD7A3) || // Hangul Syllables
+           (codePoint >= 0xF900 && codePoint <= 0xFAFF) || // CJK Compatibility Ideographs
+           (codePoint >= 0xFE30 && codePoint <= 0xFE6F) || // CJK Compatibility Forms
+           (codePoint >= 0xFF00 && codePoint <= 0xFFEF);   // Full-width Latin letters, digits, punctuation
+  }
+
+  public static void main(String[] args) {
+    String text = "Hello, 世界！";
+    int estimatedWidth = estimateWidth(text);
+    System.out.println("Estimated width: " + estimatedWidth);
+  }
+
+  public static String formatInSpecifiedWidth(int width, Object s) {
+    int numCharacters = Objects.toString(s).length();
+    int estimatedWidth = estimateWidth(Objects.toString(s));
+
+    return format("%-" + (width - (estimatedWidth - numCharacters))+ "s", s);
+  }
 }

--- a/src/main/java/com/github/valid8j/pcond/internals/InternalUtils.java
+++ b/src/main/java/com/github/valid8j/pcond/internals/InternalUtils.java
@@ -291,7 +291,7 @@ public enum InternalUtils {
    * @return A predicate marked trivial.
    */
   public static <T> Predicate<T> makeSquashable(Predicate<T> predicate) {
-    return ((PrintablePredicate<T>) predicate).makeTrivial();
+    return ((PrintablePredicate<T>) predicate).markSquashable();
   }
 
   /**
@@ -304,7 +304,7 @@ public enum InternalUtils {
    * @return A function marked trivial.
    */
   public static <T, R> Function<T, R> makeSquashable(Function<T, R> function) {
-    return ((PrintableFunction<T, R>) function).makeTrivial();
+    return ((PrintableFunction<T, R>) function).markSquashable();
   }
 
   public static <T> Function<T, T> trivialIdentityFunction() {

--- a/src/main/java/com/github/valid8j/pcond/validator/ReportComposer.java
+++ b/src/main/java/com/github/valid8j/pcond/validator/ReportComposer.java
@@ -11,6 +11,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import static com.github.valid8j.pcond.internals.InternalUtils.*;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.lang.String.format;
@@ -68,10 +69,10 @@ public interface ReportComposer {
   }
 
   class FormattedEntry {
-    private final String  input;
-    private final String  formName;
-    private final String  indent;
-    private final String  output;
+    private final String input;
+    private final String formName;
+    private final String indent;
+    private final String output;
     private final boolean requiresExplanation;
 
     public FormattedEntry(String input, String formName, String indent, String output, boolean requiresExplanation) {
@@ -135,30 +136,30 @@ public interface ReportComposer {
 
     public static FormattedEntry createFormattedEntryForExpectation(ReportComposer reportComposer, EvaluationEntry entry) {
       return new FormattedEntry(
-          InternalUtils.formatObject(entry.inputExpectation()),
+          formatObject(entry.inputExpectation()),
           entry.formName(),
           InternalUtils.indent(entry.level()),
-          InternalUtils.formatObject(entry.outputExpectation()),
+          formatObject(entry.outputExpectation()),
           reportComposer.requiresExplanation(entry));
     }
 
     public static FormattedEntry createFormattedEntryForActualValue(ReportComposer reportComposer, EvaluationEntry entry) {
       return new FormattedEntry(
-          InternalUtils.formatObject(entry.inputActualValue()),
+          formatObject(entry.inputActualValue()),
           entry.formName(),
           InternalUtils.indent(entry.level()),
-          InternalUtils.formatObject(entry.outputActualValue()),
+          formatObject(entry.outputActualValue()),
           reportComposer.requiresExplanation(entry));
     }
 
     private static List<FormattedEntry> minimizeIndentation(List<FormattedEntry> summaryForActual) {
       String minIndent = summaryForActual.stream()
-          .map(e -> e.indent)
-          .min(Comparator.comparingInt(String::length))
-          .orElse("");
+                                         .map(e -> e.indent)
+                                         .min(Comparator.comparingInt(String::length))
+                                         .orElse("");
       return summaryForActual.stream()
-          .map(e -> new FormattedEntry(e.input, e.formName(), e.indent().replaceFirst(minIndent, ""), e.output, e.requiresExplanation()))
-          .collect(toList());
+                             .map(e -> new FormattedEntry(e.input, e.formName(), e.indent().replaceFirst(minIndent, ""), e.output, e.requiresExplanation()))
+                             .collect(toList());
     }
 
     private static List<EvaluationEntry> squashTrivialEntries(ReportComposer reportComposer, List<EvaluationEntry> evaluationHistory) {
@@ -167,33 +168,33 @@ public interface ReportComposer {
         List<EvaluationEntry> entriesToSquash = new LinkedList<>();
         AtomicReference<EvaluationEntry> cur = new AtomicReference<>();
         evaluationHistory.stream()
-            .filter(each -> !each.ignored() || DebuggingUtils.reportIgnoredEntries())
-            .filter(each -> {
-              if (cur.get() != null)
-                return true;
-              else {
-                cur.set(each);
-                return false;
-              }
-            })
-            .forEach(each -> {
-              if (entriesToSquash.isEmpty()) {
-                if (cur.get().isSquashable(each) && !suppressSquashing()) {
-                  entriesToSquash.add(cur.get());
-                } else {
-                  ret.add(cur.get());
-                }
-              } else {
-                entriesToSquash.add(cur.get());
-                ret.add(squashEntries(reportComposer, entriesToSquash));
-                entriesToSquash.clear();
-              }
-              cur.set(each);
-            });
+                         .filter(each -> !each.ignored() || DebuggingUtils.reportIgnoredEntries())
+                         .filter(each -> {
+                           if (cur.get() != null)
+                             return true;
+                           else {
+                             cur.set(each);
+                             return false;
+                           }
+                         })
+                         .forEach(each -> {
+                           if (entriesToSquash.isEmpty()) {
+                             if (cur.get().isSquashable(each) && !suppressSquashing()) {
+                               entriesToSquash.add(cur.get());
+                             } else {
+                               ret.add(cur.get());
+                             }
+                           } else {
+                             entriesToSquash.add(cur.get());
+                             ret.add(squashEntries(reportComposer, entriesToSquash));
+                             entriesToSquash.clear();
+                           }
+                           cur.set(each);
+                         });
         finishLeftOverEntries(reportComposer, ret, entriesToSquash, cur);
         return ret.stream()
-            .filter(e -> !(e.inputActualValue() instanceof ValueHolder))
-            .collect(toList());
+                  .filter(e -> !(e.inputActualValue() instanceof ValueHolder))
+                  .collect(toList());
       } else {
         return new ArrayList<>(evaluationHistory);
       }
@@ -214,9 +215,9 @@ public interface ReportComposer {
       EvaluationEntry first = squashedItems.get(0);
       return EvaluationEntry.create(
           squashedItems.stream()
-              .map(e -> (EvaluationEntry.Impl) e)
-              .map(EvaluationEntry::formName)
-              .collect(joining(":")),
+                       .map(e -> (EvaluationEntry.Impl) e)
+                       .map(EvaluationEntry::formName)
+                       .collect(joining(":")),
           first.type(),
           first.level(),
           first.inputExpectation(), first.detailInputExpectation(),
@@ -234,10 +235,10 @@ public interface ReportComposer {
 
     private static String computeDetailOutputExpectationFromSquashedItems(List<EvaluationEntry> squashedItems) {
       return squashedItems.stream()
-          .filter(e -> e.type() != EvaluationEntry.Type.TRANSFORM && e.type() != EvaluationEntry.Type.CHECK)
-          .map(EvaluationEntry::detailOutputExpectation)
-          .map(Objects::toString)
-          .collect(joining(":"));
+                          .filter(e -> e.type() != EvaluationEntry.Type.TRANSFORM && e.type() != EvaluationEntry.Type.CHECK)
+                          .map(EvaluationEntry::detailOutputExpectation)
+                          .map(Objects::toString)
+                          .collect(joining(":"));
     }
 
     private static void addToDetailsListIfExplanationIsRequired(ReportComposer reportComposer, List<Object> detailsForExpectation, EvaluationEntry evaluationEntry, Supplier<Object> detailOutput) {
@@ -248,9 +249,9 @@ public interface ReportComposer {
     static Report composeReport(String summary, List<Object> details) {
       List<String> stringFormDetails = details != null ?
           details.stream()
-              .filter(Objects::nonNull)
-              .map(Objects::toString)
-              .collect(toList()) :
+                 .filter(Objects::nonNull)
+                 .map(Objects::toString)
+                 .collect(toList()) :
           emptyList();
       return Report.create(summary, stringFormDetails);
     }
@@ -289,16 +290,18 @@ public interface ReportComposer {
               format("%-4s", formattedEntry.requiresExplanation ?
                   "[" + i.getAndIncrement() + "]" : "") :
               "") +
-              String.format("%-" + max(2, inputColumnWidth) + "s" +
-                      "%-" + (formNameColumnLength + 2) + "s" +
-                      "%-" + max(2, outputColumnLength) + "s",
-                  formattedEntry.input().orElse(""),
-                  formattedEntry.input()
-                      .map(v -> "->")
-                      .orElse("  ") + InternalUtils.formatObject(InternalUtils.toNonStringObject(formattedEntry.indent() + formattedEntry.formName()), formNameColumnLength - 2),
-                  formattedEntry
-                      .output()
-                      .map(v -> "->" + v).orElse(""));
+          formatFields(inputColumnWidth, formNameColumnLength, outputColumnLength, formattedEntry);
+    }
+
+    private static String formatFields(int inputColumnWidth, int formNameColumnLength, int outputColumnLength, FormattedEntry formattedEntry) {
+      return formatInSpecifiedWidth(max(2, inputColumnWidth), formattedEntry.input()
+                                                                            .orElse("")) +
+             formatInSpecifiedWidth(formNameColumnLength + 2, formattedEntry.input()
+                                                                            .map(v -> "->")
+                                                                            .orElse("  ") + formatObject(toNonStringObject(formattedEntry.indent() + formattedEntry.formName()), formNameColumnLength - 2)) +
+             formatInSpecifiedWidth(max(2, outputColumnLength), formattedEntry.output()
+                                                                              .map(v -> "->" + v)
+                                                                              .orElse(""));
     }
 
     private static String evaluatorEntriesToString(List<FormattedEntry> formattedEntries, Function<int[], Function<FormattedEntry, String>> formatterFactory) {
@@ -318,7 +321,7 @@ public interface ReportComposer {
           DebuggingUtils.showEvaluableDetail() ? 80 : 12,
           Math.min(InternalUtils.summarizedStringLength(), maxIndentAndFormNameLength))) + formNameColumnLength % 2;
       Function<FormattedEntry, String> formatter = formatterFactory.apply(
-          new int[] { maxInputLength, formNameColumnLength, maxOutputLength });
+          new int[]{maxInputLength, formNameColumnLength, maxOutputLength});
       return formattedEntries
           .stream()
           .map(formatter)
@@ -329,15 +332,15 @@ public interface ReportComposer {
     private static List<FormattedEntry> hideInputValuesWhenRepeated(List<FormattedEntry> formattedEntries) {
       AtomicReference<Object> previousInput = new AtomicReference<>();
       return formattedEntries.stream()
-          .map(each -> {
-            if (!Objects.equals(previousInput.get(), each.input())) {
-              previousInput.set(each.input());
-              return each;
-            } else {
-              return new FormattedEntry("", each.formName(), each.indent(), each.output().orElse(null), each.requiresExplanation());
-            }
-          })
-          .collect(toList());
+                             .map(each -> {
+                               if (!Objects.equals(previousInput.get(), each.input())) {
+                                 previousInput.set(each.input());
+                                 return each;
+                               } else {
+                                 return new FormattedEntry("", each.formName(), each.indent(), each.output().orElse(null), each.requiresExplanation());
+                               }
+                             })
+                             .collect(toList());
     }
 
 

--- a/src/test/java/com/github/valid8j/examples/metamor/MetamorExampleBase.java
+++ b/src/test/java/com/github/valid8j/examples/metamor/MetamorExampleBase.java
@@ -228,7 +228,7 @@ public abstract class MetamorExampleBase {
     return ((PrintableFunction<String, String>) Printables.function("toUpperCase", (String s) -> {
       System.out.println("s:" + s);
       return s.toUpperCase();
-    })).makeTrivial();
+    })).markSquashable();
   }
 
   private static Function<String, String> createFunction() {


### PR DESCRIPTION
Rectify method/field names of 'trivial' in 'PrintableFunction'.
Now they are uniformly called 'squashable' (field name) or 'isSquashable' (method name).
